### PR TITLE
adds publications page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
 
 PLATFORMS
   universal-darwin-21
+  universal-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/_includes/publications.md
+++ b/_includes/publications.md
@@ -1,0 +1,9 @@
+## Publications
+
+1. [Logical Synchrony and the bittide Mechanism](http://arxiv.org/abs/2308.00144) describes the logical time abstraction and how distributed processes may be synchronized within it. The invariants of the system are analyzed, and the latency properties are characterized.
+
+1. [Modeling and Control of bittide Synchronization](https://arxiv.org/abs/2109.14111) ([2022 American Control Conference](https://ieeexplore.ieee.org/xpl/conhome/9866948/proceeding)) describes the design of the system, including how frames are communicated within bittide, and how communication is synchronized with computation to provide applications with a perfect logical clock. The paper develops a mathematical model for the clock behaviors and shows some example simulations.
+
+1. [Resistance Distance and Control Performance](https://arxiv.org/abs/2111.05296) ([2022 European Control Conference](https://ieeexplore.ieee.org/xpl/conhome/9837955/proceeding)) for bittide Synchronization analyzes the frequency synchronization mechanism of bittide, and develops quantitative methods for analyzing its performance, in particular focusing on the sizes of frequency deviations and buffer occupancies.
+
+1. [On Buffer Centering for bittide Synchronization](https://arxiv.org/abs/2303.11467) ([CoDIT 2023](https://codit2023.com/)) develops an algorithmic refinement of the bittide mechanism which allows precise control of the buffer occupancies.

--- a/index.markdown
+++ b/index.markdown
@@ -1,8 +1,7 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
 layout: home
 ---
+
  bittide is building system architectures for synchronous distributed computing. For more info go to [github.com/bittide](https://github.com/bittide)
 
+{% include publications.md %}


### PR DESCRIPTION
Adds a pubs page, essentially a copy of your Google doc.

Given the sparsity of the site, I posted it on the front page. But it is in a separate file that can be included in a different layout should the site grow.

I added the venues for the published papers, but not the authors -- so not really reference style. 